### PR TITLE
Update logging dependency log4j to 2.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ workingdir
 ${sys:logFilename}
 drivestrength.log
 src/test/java/de/uni_potsdam/hpi/asg/drivestrength/Drivestrength*MainTest.java
+.factorypath
+.vscode

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 ASGdrivestrength v1.0
-Copyright (C) 2016-2017 Florian Meinel
+Copyright (C) 2016-2021 Florian Meinel
 
 This software is licensed under the GNU GENERAL PUBLIC LICENSE Version 3 (http://www.fsf.org/licensing/licenses/gpl-3.0.html) ("GPL") to all third parties and that license, as required by the GPL, is included in the LICENSE.txt file.
 
@@ -10,9 +10,9 @@ http://commons.apache.org/proper/commons-math/
 Copyright 2001-2017 The Apache Software Foundation
 Licensed under the Apache License, Version 2.0
 
-Apache log4j(TM) v2.1
+Apache log4j(TM) v2.15
 http://logging.apache.org/log4j/2.x/
-Copyright (C) 1999-2014 Apache Software Foundation
+Copyright (C) 1999-2021 Apache Software Foundation
 Licensed under Apache License, Version 2.0
 
 args4j v2.33

--- a/pom.xml
+++ b/pom.xml
@@ -246,12 +246,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.1</version>
+			<version>2.15</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.1</version>
+			<version>2.15</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	</prerequisites>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<common.version>3.0.0</common.version>
+		<common.version>3.0.1</common.version>
 	</properties>
 	<build>
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -246,12 +246,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.15</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.15</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.uni_potsdam.hpi.asg</groupId>
 	<artifactId>asgdrivestrength</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<organization>
 		<name>Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH</name>
 		<url>http://www.hpi.uni-potsdam.de</url>


### PR DESCRIPTION
to avoid vulnerability CVE-2021-44228